### PR TITLE
feat: add label-on-comment workflow to repo

### DIFF
--- a/.github/workflows/add-remove-label-on-comment.yml
+++ b/.github/workflows/add-remove-label-on-comment.yml
@@ -15,6 +15,6 @@ on:
     types: [created]
 
 jobs:
-  add_label:
-    uses: openedx/.github/.github/workflows/label-on-comment.yml@master
+  add_remove_labels:
+    uses: openedx/.github/.github/workflows/add-remove-label-on-comment.yml@master
 

--- a/.github/workflows/label-on-comment.yml
+++ b/.github/workflows/label-on-comment.yml
@@ -1,4 +1,14 @@
-name: Allows for the adding and removing of labels via comment 
+# This workflow runs when a comment is made on the ticket
+# If the comment starts with "label: " it tries to apply
+# the label indicated in rest of comment.
+# If the comment starts with "remove label: ", it tries
+# to remove the indicated label.
+# Note: Labels are allowed to have spaces and this script does
+# not parse spaces (as often a space is legitimate), so the command
+# "label: really long lots of words label" will apply the
+# label "really long lots of words label"
+
+name: Allows for the adding and removing of labels via comment
 
 on:
   issue_comment:
@@ -6,8 +16,5 @@ on:
 
 jobs:
   add_label:
-    uses: openedx/.github/.github/workflows/label-on-comment.yml@master
-
-  remove_label:
     uses: openedx/.github/.github/workflows/label-on-comment.yml@master
 

--- a/.github/workflows/label-on-comment.yml
+++ b/.github/workflows/label-on-comment.yml
@@ -1,0 +1,13 @@
+name: Allows for the adding and removing of labels via comment 
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  add_label:
+    uses: openedx/.github/.github/workflows/label-on-comment.yml@master
+
+  remove_label:
+    uses: openedx/.github/.github/workflows/label-on-comment.yml@master
+


### PR DESCRIPTION
Closes https://github.com/openedx/tcril-engineering/issues/322

This will grant the arbi-bom team the ability to edit labels of Github issues, much like how the BTR WG does in the BTR WG repo.